### PR TITLE
Use CUPS constants from bindings.rs to allow building for different target architectures

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -124,7 +124,7 @@ impl Destination {
                 flags.into(),
                 timeout,
                 cancel_ptr,
-                resource_buf.as_mut_ptr() as *mut i8,
+                resource_buf.as_mut_ptr() as *mut ::std::os::raw::c_char,
                 RESOURCE_SIZE,
                 None, // No callback for now
                 ptr::null_mut(), // No user data
@@ -205,7 +205,7 @@ impl Destination {
                 flags.into(),
                 timeout,
                 cancel_ptr,
-                resource_buf.as_mut_ptr() as *mut i8,
+                resource_buf.as_mut_ptr() as *mut ::std::os::raw::c_char,
                 RESOURCE_SIZE,
                 Some(connect_dest_callback::<T>),
                 &mut context as *mut _ as *mut c_void,

--- a/src/destination/dest_info.rs
+++ b/src/destination/dest_info.rs
@@ -262,7 +262,7 @@ impl DestinationInfo {
         let name_bytes = size.name.as_bytes();
         let max_len = 127.min(name_bytes.len());
         for i in 0..max_len {
-            cups_size.media[i] = name_bytes[i] as i8;
+            cups_size.media[i] = name_bytes[i] as ::std::os::raw::c_char;
         }
         cups_size.media[max_len] = 0;
 

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -185,7 +185,7 @@ impl Job {
             let result = unsafe {
                 bindings::cupsWriteRequestData(
                     ptr::null_mut(),
-                    chunk.as_ptr() as *const i8,
+                    chunk.as_ptr() as *const ::std::os::raw::c_char,
                     chunk_size,
                 )
             };

--- a/src/job/status.rs
+++ b/src/job/status.rs
@@ -14,27 +14,27 @@ pub enum JobStatus {
 
 impl JobStatus {
     pub fn from_cups_state(state: i32) -> Self {
-        match state {
-            3 => JobStatus::Pending,
-            4 => JobStatus::Processing,
-            5 => JobStatus::Completed,
-            6 => JobStatus::Canceled,
-            7 => JobStatus::Aborted,
-            8 => JobStatus::Held,
-            9 => JobStatus::Stopped,
+        match state as u32 {
+            crate::bindings::ipp_jstate_e_IPP_JSTATE_PENDING => JobStatus::Pending,
+            crate::bindings::ipp_jstate_e_IPP_JSTATE_PROCESSING => JobStatus::Processing,
+            crate::bindings::ipp_jstate_e_IPP_JSTATE_COMPLETED => JobStatus::Completed,
+            crate::bindings::ipp_jstate_e_IPP_JSTATE_CANCELED => JobStatus::Canceled,
+            crate::bindings::ipp_jstate_e_IPP_JSTATE_ABORTED => JobStatus::Aborted,
+            crate::bindings::ipp_jstate_e_IPP_JSTATE_HELD => JobStatus::Held,
+            crate::bindings::ipp_jstate_e_IPP_JSTATE_STOPPED => JobStatus::Stopped,
             _ => JobStatus::Unknown,
         }
     }
 
     pub fn to_cups_value(&self) -> i32 {
         match self {
-            JobStatus::Pending => 3,
-            JobStatus::Processing => 4,
-            JobStatus::Completed => 5,
-            JobStatus::Canceled => 6,
-            JobStatus::Aborted => 7,
-            JobStatus::Held => 8,
-            JobStatus::Stopped => 9,
+            JobStatus::Pending => crate::bindings::ipp_jstate_e_IPP_JSTATE_PENDING as i32,
+            JobStatus::Processing => crate::bindings::ipp_jstate_e_IPP_JSTATE_PROCESSING as i32,
+            JobStatus::Completed => crate::bindings::ipp_jstate_e_IPP_JSTATE_COMPLETED as i32,
+            JobStatus::Canceled => crate::bindings::ipp_jstate_e_IPP_JSTATE_CANCELED as i32,
+            JobStatus::Aborted => crate::bindings::ipp_jstate_e_IPP_JSTATE_ABORTED as i32,
+            JobStatus::Held => crate::bindings::ipp_jstate_e_IPP_JSTATE_HELD as i32,
+            JobStatus::Stopped => crate::bindings::ipp_jstate_e_IPP_JSTATE_STOPPED as i32,
             JobStatus::Unknown => 0,
         }
     }


### PR DESCRIPTION
Different build targets or CUPS versions might have different values for JobStatus in bindings.rs. Those constants should be used instead of hard-coded values.