### PR TITLE
fix: re-export job helpers and FORMAT_* constants at crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,9 @@ pub use destination::{
 };
 pub use error::{Error, ErrorCategory, Result};
 pub use job::{
-    ColorMode, DuplexMode, JobInfo, JobStatus, Orientation, PrintOptions, PrintQuality,
-    create_job, create_job_with_options, get_active_jobs, get_completed_jobs,
+    ColorMode, DuplexMode, FORMAT_JPEG, FORMAT_PDF, FORMAT_POSTSCRIPT, FORMAT_TEXT, JobInfo,
+    JobStatus, Orientation, PrintOptions, PrintQuality, cancel_job, create_job,
+    create_job_with_options, get_active_jobs, get_completed_jobs, get_job_info, get_jobs,
 };
 pub use ipp::{
     IppAttribute, IppOperation, IppRequest, IppResponse, IppStatus, IppTag, IppValueTag,


### PR DESCRIPTION
This PR re-exports the commonly used job helpers and document format constants from `cups_rs::job` at the crate root (`cups_rs::*`). This makes the public API match the README/examples style and fixes compilation issues where examples/tests expect `FORMAT_TEXT`, `FORMAT_PDF`, `get_job_info`, `cancel_job`, and `get_jobs` to be available from the root.
